### PR TITLE
Expose function to manually setup authHeaders property

### DIFF
--- a/oak-ajax-behavior.html
+++ b/oak-ajax-behavior.html
@@ -71,7 +71,7 @@
         }
         _instances.forEach(function(instance) {
           if (instance && instance._setAuthHeaders) {
-            instance._setAuthHeaders(_headers)
+            instance.setupAuthHeaders();
           }
         });
       },
@@ -119,6 +119,13 @@
         _instances = _instances.filter(function(_instance) {
           return this !== _instance;
         }.bind(this));
+      },
+
+      /**
+       * Setup authHeaders property.
+       */
+      setupAuthHeaders: function() {
+        this._setAuthHeaders(_headers);
       }
     };
   })();


### PR DESCRIPTION
## Problem
When a web component is dynamically loaded using `importHref()` instead of `<link rel="import"/>`, `OakAjaxBehavior.setSessionId()`, which sets up the `authHeaders` property, isn't getting called by the MS Edge browser.  This results in the web component not having `authHeaders` and getting a `401` error when making network requests.

### Changes
- Created a public function that can be called to setup `authHeaders`.